### PR TITLE
Fix small compiler errors for updated GCC

### DIFF
--- a/external/gpl/lzo/GNUmakefile
+++ b/external/gpl/lzo/GNUmakefile
@@ -1,9 +1,9 @@
 
 ifeq ($(USE_GCC_VERBOSE), 1)
-	CC = gcc
+	CC = gcc -std=gnu89
 	PUT_FILENAME =
 else
-	CC = @gcc
+	CC = @gcc -std=gnu89
 	PUT_FILENAME = @echo $<
 endif
 

--- a/source/stem_krovetz.h
+++ b/source/stem_krovetz.h
@@ -94,7 +94,7 @@ private:
 
 	#if defined(ATIRE_KROVETZ_HAS_UNORDERED_MAP)
 		struct eqstr {bool operator()(const char* s1, const char* s2) const { return strcmp(s1, s2) == 0; }};
-		typedef unordered_map<const char *, dictEntry, hash<string>, eqstr> dictTable;
+		typedef unordered_map<const char *, dictEntry, std::hash<std::string>, eqstr> dictTable;
 	#elif defined (ATIRE_KROVETZ_HAS_HASH_MAP)
 		struct eqstr {bool operator()(const char* s1, const char* s2) const { return strcmp(s1, s2) == 0; }};
 		typedef hash_map<const char *, dictEntry, hash<const char *>, eqstr> dictTable;


### PR DESCRIPTION
New GCC causes a few strange bugs on building. These changes don't (read: shouldn't) impact older compilers.